### PR TITLE
Fixed incomplete content if client's connection is closed

### DIFF
--- a/src/ngx_http_small_light_module.c
+++ b/src/ngx_http_small_light_module.c
@@ -526,7 +526,10 @@ static ngx_int_t ngx_http_small_light_image_read(ngx_http_request_t *r, ngx_chai
         b->pos += size;
         if (b->last_buf) {
             ctx->last = p;
-            return NGX_OK;
+            if (ctx->last - ctx->content == ctx->content_length)
+                return NGX_OK;
+            else
+                return NGX_ERROR;
         }
     }
 


### PR DESCRIPTION
I fix not handle incomplete content from upstream if client's connection is closed.
Client's connection is closed, and then occur event and stop receive content from upstream, because nginx is asynchronous event driven http server.
