### PR TITLE
Remove redundant @my_libs@ from config

### DIFF
--- a/setup
+++ b/setup
@@ -102,6 +102,7 @@ my $imlib2_libs     = "";
 my $imlib2_includes = "";
 if ($imlib2_enabled == 1) {
     $imlib2_libs     = `imlib2-config --libs`;
+    $imlib2_libs     =~ s/\s*?\@my_libs\@\s*?//;
     $imlib2_includes = `imlib2-config --cflags`;
     chomp($imlib2_libs);
     chomp($imlib2_includes);


### PR DESCRIPTION
"imlib2-config --libs" of imlib2 1.4.6 generates a redundant string @my_libs@, which breaks the build of ngx_small_light.

reference:
http://kmandla.wordpress.com/2014/05/10/imlib2-and-my_libs/
