### PR TITLE
Avoid ImageMagick semaphore error

### DIFF
--- a/src/ngx_http_small_light_imagemagick.c
+++ b/src/ngx_http_small_light_imagemagick.c
@@ -32,7 +32,6 @@ extern const char *ngx_http_small_light_image_types[];
 ngx_int_t ngx_http_small_light_imagemagick_init(ngx_http_request_t *r, ngx_http_small_light_ctx_t *ctx)
 {
     ngx_http_small_light_imagemagick_ctx_t *ictx;
-    MagickWandGenesis();
     ictx            = (ngx_http_small_light_imagemagick_ctx_t *)ctx->ictx;
     ictx->wand      = NewMagickWand();
     ictx->image     = ctx->content;
@@ -61,7 +60,6 @@ void ngx_http_small_light_imagemagick_term(void *data)
     }
 
     DestroyMagickWand(ictx->wand);
-    MagickWandTerminus();
 }
 
 /** 
@@ -400,4 +398,14 @@ ngx_int_t ngx_http_small_light_imagemagick_process(ngx_http_request_t *r, ngx_ht
     ictx->complete = 1;
 
     return NGX_OK;
+}
+
+void ngx_http_small_light_imagemagick_genesis(void)
+{
+    MagickWandGenesis();
+}
+
+void ngx_http_small_light_imagemagick_terminus(void)
+{
+    MagickWandTerminus();
 }

--- a/src/ngx_http_small_light_imagemagick.h
+++ b/src/ngx_http_small_light_imagemagick.h
@@ -39,4 +39,7 @@ ngx_int_t ngx_http_small_light_imagemagick_init(ngx_http_request_t *r, ngx_http_
 ngx_int_t ngx_http_small_light_imagemagick_process(ngx_http_request_t *r, ngx_http_small_light_ctx_t *ctx);
 void ngx_http_small_light_imagemagick_term(void *data);
 
+void ngx_http_small_light_imagemagick_genesis(void);
+void ngx_http_small_light_imagemagick_terminus(void);
+
 #endif /* NGX_HTTP_SMALL_LIGHT_IMAGEMAGICK_H */

--- a/src/ngx_http_small_light_module.c
+++ b/src/ngx_http_small_light_module.c
@@ -151,16 +151,12 @@ ngx_module_t  ngx_http_small_light_module = {
 };
 
 static ngx_int_t ngx_http_small_light_init_worker(ngx_cycle_t *cycle) {
-    /* TODO: Consider about other image processors */
-
     ngx_http_small_light_imagemagick_genesis();
 
     return NGX_OK;
 }
 
 static void ngx_http_small_light_exit_worker(ngx_cycle_t *cycle) {
-    /* TODO: Consider about other image processors */
-
     ngx_http_small_light_imagemagick_terminus();
 }
 

--- a/src/ngx_http_small_light_module.c
+++ b/src/ngx_http_small_light_module.c
@@ -137,16 +137,16 @@ static ngx_http_module_t  ngx_http_small_light_module_ctx = {
 
 ngx_module_t  ngx_http_small_light_module = {
     NGX_MODULE_V1,
-    &ngx_http_small_light_module_ctx,  /* module context */
-    ngx_http_small_light_commands,     /* module directives */
-    NGX_HTTP_MODULE,                   /* module type */
-    NULL,                              /* init master */
-    NULL,                              /* init module */
-    ngx_http_small_light_init_worker,  /* init process */
-    NULL,                              /* init thread */
-    NULL,                              /* exit thread */
-    ngx_http_small_light_exit_worker,  /* exit process */
-    NULL,                              /* exit master */
+    &ngx_http_small_light_module_ctx, /* module context */
+    ngx_http_small_light_commands,    /* module directives */
+    NGX_HTTP_MODULE,                  /* module type */
+    NULL,                             /* init master */
+    NULL,                             /* init module */
+    ngx_http_small_light_init_worker, /* init process */
+    NULL,                             /* init thread */
+    NULL,                             /* exit thread */
+    ngx_http_small_light_exit_worker, /* exit process */
+    NULL,                             /* exit master */
     NGX_MODULE_V1_PADDING
 };
 

--- a/src/ngx_http_small_light_module.c
+++ b/src/ngx_http_small_light_module.c
@@ -60,8 +60,8 @@ static char *ngx_http_small_light_material_dir(ngx_conf_t *cf, ngx_command_t *cm
 static ngx_int_t ngx_http_small_light_image_read(ngx_http_request_t *r, ngx_chain_t *in, size_t buffer_size, ngx_http_small_light_ctx_t *ctx);
 static ngx_int_t ngx_http_small_light_finish(ngx_http_request_t *r, ngx_chain_t *out);
 static ngx_int_t ngx_http_small_light_init(ngx_conf_t *cf);
-static ngx_int_t ngx_http_small_light_init_process(ngx_cycle_t *cycle);
-static void ngx_http_small_light_exit_process(ngx_cycle_t *cycle);
+static ngx_int_t ngx_http_small_light_init_worker(ngx_cycle_t *cycle);
+static void ngx_http_small_light_exit_worker(ngx_cycle_t *cycle);
 
 static ngx_command_t  ngx_http_small_light_commands[] = {
     { 
@@ -142,15 +142,15 @@ ngx_module_t  ngx_http_small_light_module = {
     NGX_HTTP_MODULE,                   /* module type */
     NULL,                              /* init master */
     NULL,                              /* init module */
-    ngx_http_small_light_init_process, /* init process */
+    ngx_http_small_light_init_worker,  /* init process */
     NULL,                              /* init thread */
     NULL,                              /* exit thread */
-    ngx_http_small_light_exit_process, /* exit process */
+    ngx_http_small_light_exit_worker,  /* exit process */
     NULL,                              /* exit master */
     NGX_MODULE_V1_PADDING
 };
 
-static ngx_int_t ngx_http_small_light_init_process(ngx_cycle_t *cycle) {
+static ngx_int_t ngx_http_small_light_init_worker(ngx_cycle_t *cycle) {
     /* TODO: Consider about other image processors */
 
     ngx_http_small_light_imagemagick_genesis();
@@ -158,7 +158,7 @@ static ngx_int_t ngx_http_small_light_init_process(ngx_cycle_t *cycle) {
     return NGX_OK;
 }
 
-static void ngx_http_small_light_exit_process(ngx_cycle_t *cycle) {
+static void ngx_http_small_light_exit_worker(ngx_cycle_t *cycle) {
     /* TODO: Consider about other image processors */
 
     ngx_http_small_light_imagemagick_terminus();

--- a/src/ngx_http_small_light_module.c
+++ b/src/ngx_http_small_light_module.c
@@ -60,6 +60,8 @@ static char *ngx_http_small_light_material_dir(ngx_conf_t *cf, ngx_command_t *cm
 static ngx_int_t ngx_http_small_light_image_read(ngx_http_request_t *r, ngx_chain_t *in, size_t buffer_size, ngx_http_small_light_ctx_t *ctx);
 static ngx_int_t ngx_http_small_light_finish(ngx_http_request_t *r, ngx_chain_t *out);
 static ngx_int_t ngx_http_small_light_init(ngx_conf_t *cf);
+static ngx_int_t ngx_http_small_light_init_process(ngx_cycle_t *cycle);
+static void ngx_http_small_light_exit_process(ngx_cycle_t *cycle);
 
 static ngx_command_t  ngx_http_small_light_commands[] = {
     { 
@@ -135,18 +137,32 @@ static ngx_http_module_t  ngx_http_small_light_module_ctx = {
 
 ngx_module_t  ngx_http_small_light_module = {
     NGX_MODULE_V1,
-    &ngx_http_small_light_module_ctx, /* module context */
-    ngx_http_small_light_commands,    /* module directives */
-    NGX_HTTP_MODULE,                  /* module type */
-    NULL,                             /* init master */
-    NULL,                             /* init module */
-    NULL,                             /* init process */
-    NULL,                             /* init thread */
-    NULL,                             /* exit thread */
-    NULL,                             /* exit process */
-    NULL,                             /* exit master */
+    &ngx_http_small_light_module_ctx,  /* module context */
+    ngx_http_small_light_commands,     /* module directives */
+    NGX_HTTP_MODULE,                   /* module type */
+    NULL,                              /* init master */
+    NULL,                              /* init module */
+    ngx_http_small_light_init_process, /* init process */
+    NULL,                              /* init thread */
+    NULL,                              /* exit thread */
+    ngx_http_small_light_exit_process, /* exit process */
+    NULL,                              /* exit master */
     NGX_MODULE_V1_PADDING
 };
+
+static ngx_int_t ngx_http_small_light_init_process(ngx_cycle_t *cycle) {
+    /* TODO: Consider about other image processors */
+
+    ngx_http_small_light_imagemagick_genesis();
+
+    return NGX_OK;
+}
+
+static void ngx_http_small_light_exit_process(ngx_cycle_t *cycle) {
+    /* TODO: Consider about other image processors */
+
+    ngx_http_small_light_imagemagick_terminus();
+}
 
 static ngx_http_output_header_filter_pt  ngx_http_next_header_filter;
 static ngx_http_output_body_filter_pt    ngx_http_next_body_filter;


### PR DESCRIPTION
Hello,

When I made requests to nginx with ngx_small_light at 40 reqs/sec, ImageMagick sometimes raised semaphore error like below.
On CoreOS, coredump has generated by this error.

```
ocess: magick/semaphore.c:339: LockSemaphoreInfo: Assertion `semaphore_info != (SemaphoreInfo *) ((void *)0)' failed.
```

As a result of my investigation, calling `MagickWandGenesis()` and `MagickWandTerminus()` per every request causes this error.
In this PR, I wrote a patch to call `MagickWandGenesis()` and `MagickWandTerminus()` at the beginning/end of process.
It works fine for me.

* * *

But I'm sorry, currently https://github.com/dtan4/ngx_small_light/commit/5bcf794a3551a1345e1e661f46dac1bf332eef71 does not have compatibility with image processors except ImageMagick.

@cubicdaiya What should I do to solve this?

## REF
- https://github.com/gographics/imagick/issues/26#issuecomment-69168587
- http://www.imagemagick.org/discourse-server/viewtopic.php?t=10129#p31709
- http://shimada-k.hateblo.jp/entry/20110804/1312386221