### PR TITLE
Fix color-inversion of JPEG in CMYK colorspace

### DIFF
--- a/src/ngx_http_small_light_imagemagick.c
+++ b/src/ngx_http_small_light_imagemagick.c
@@ -85,6 +85,7 @@ ngx_int_t ngx_http_small_light_imagemagick_process(ngx_http_request_t *r, ngx_ht
     size_t                                  embedicon_path_len, embedicon_len, sled_image_size;
     ngx_int_t                               type;
     u_char                                  jpeg_size_opt[32], crop_geo[128], size_geo[128], embedicon_path[256];
+    ColorspaceType                          color_space;
 
     status = MagickFalse;
 
@@ -113,6 +114,8 @@ ngx_int_t ngx_http_small_light_imagemagick_process(ngx_http_request_t *r, ngx_ht
                       __LINE__);
         return NGX_ERROR;
     }
+
+    color_space = MagickGetImageColorspace(ictx->wand);
 
     /* remove all profiles */
     rmprof_flg = ngx_http_small_light_parse_flag(NGX_HTTP_SMALL_LIGHT_PARAM_GET_LIT(&ctx->hash, "rmprof"));
@@ -189,6 +192,13 @@ ngx_int_t ngx_http_small_light_imagemagick_process(ngx_http_request_t *r, ngx_ht
             r->err_status = NGX_HTTP_INTERNAL_SERVER_ERROR;
             return NGX_ERROR;
         }
+
+        status = MagickTransformImageColorspace(canvas_wand, color_space);
+        if (status == MagickFalse) {
+            r->err_status = NGX_HTTP_INTERNAL_SERVER_ERROR;
+            return NGX_ERROR;
+        }
+
         status = MagickCompositeImage(canvas_wand, ictx->wand, AtopCompositeOp, sz.dx, sz.dy);
         if (status == MagickFalse) {
             r->err_status = NGX_HTTP_INTERNAL_SERVER_ERROR;


### PR DESCRIPTION
Hello,

When I tried to convert __JPEG in CMYK colorspace__ with __`cw` and `ch` option__, the color of result image is inverted.
Here is an example,

#### Environments

- Nginx 1.6.2
- ImageMagick 6.8.6-8
- ngx_small_light 0.6.5

#### Original image

![fujisan](https://cloud.githubusercontent.com/assets/680124/6480723/1a5ce772-c29a-11e4-9403-cc25661bd4f0.jpg)

#### Result image (small_light param: `small_light(cw=300,ch=300)`)

![fujisan_inverted](https://cloud.githubusercontent.com/assets/680124/6480722/15e017d2-c29a-11e4-9681-2f90d75a9537.jpg)

This problem was NOT reproduced by `convert` command, like this:

```bash
$ convert fujisan_cmyk.jpg -thumbnail 300x300 fujisan_chisai.jpg
```

I also found that the colorspace of color-inverted result image was changed from CMYK to sRGB.

```bash
$ identify fujisan_cmyk.jpg
fujisan_cmyk.jpg JPEG 700x465 700x465+0+0 8-bit CMYK 221KB 0.000u 0:00.000
$ identify fujisan_inverted.jpg
fujisan_inverted.jpg JPEG 300x300 300x300+0+0 8-bit sRGB 22.7KB 0.000u 0:00.000
```

* * *

In this PR, I made converted image use the same colorspace as original image's.
With this patch, there is no more color-inversion problem.

#### Result image (patched-small_light param: `small_light(cw=300,ch=300)`)

![fujisan_good](https://cloud.githubusercontent.com/assets/680124/6480873/b3a68e00-c29b-11e4-83f9-1efc720ce76d.jpg)