### PR TITLE
imagemagick: introduced ngx_http_small_light_imagemagick_set_thread_limit(1).

### DIFF
--- a/src/ngx_http_small_light_imagemagick.c
+++ b/src/ngx_http_small_light_imagemagick.c
@@ -435,3 +435,13 @@ void ngx_http_small_light_imagemagick_terminus(void)
 {
     MagickWandTerminus();
 }
+
+int ngx_http_small_light_imagemagick_set_thread_limit(int limit)
+{
+    MagickBooleanType status;
+    status = MagickSetResourceLimit(ThreadResource, limit);
+    if (status == MagickFalse) {
+        return 0;
+    }
+    return 1;
+}

--- a/src/ngx_http_small_light_imagemagick.h
+++ b/src/ngx_http_small_light_imagemagick.h
@@ -41,5 +41,6 @@ void ngx_http_small_light_imagemagick_term(void *data);
 
 void ngx_http_small_light_imagemagick_genesis(void);
 void ngx_http_small_light_imagemagick_terminus(void);
+int ngx_http_small_light_imagemagick_set_thread_limit(int limit);
 
 #endif /* NGX_HTTP_SMALL_LIGHT_IMAGEMAGICK_H */

--- a/src/ngx_http_small_light_module.c
+++ b/src/ngx_http_small_light_module.c
@@ -156,6 +156,10 @@ ngx_module_t  ngx_http_small_light_module = {
 static ngx_int_t ngx_http_small_light_init_worker(ngx_cycle_t *cycle) {
     ngx_http_small_light_imagemagick_genesis();
 
+    if (ngx_http_small_light_imagemagick_set_thread_limit(1) == 0) {
+        ngx_log_error(NGX_LOG_WARN, cycle->log, 0,
+                      "failed to set thread limit");
+    }
     return NGX_OK;
 }
 


### PR DESCRIPTION
In the use-scene of ngx_small_light, Enabling multihthreading with OpenMP is not recommended. So the running thread-number should be always 1.