### PR TITLE
Copy original image profiles when create new canvas

### DIFF
--- a/src/ngx_http_small_light_imagemagick.c
+++ b/src/ngx_http_small_light_imagemagick.c
@@ -240,18 +240,18 @@ ngx_int_t ngx_http_small_light_imagemagick_process(ngx_http_request_t *r, ngx_ht
         /* copy original image profiles to the new canvas. */
         origin_image_profiles = MagickGetImageProfiles(ictx->wand, "*", &profile_count);
         if (origin_image_profiles != (char **) NULL) {
-          for (i = 0; i < profile_count; i++) {
-            profile = MagickGetImageProfile(ictx->wand, origin_image_profiles[i], &profile_len);
+            for (i = 0; i < profile_count; i++) {
+                profile = MagickGetImageProfile(ictx->wand, origin_image_profiles[i], &profile_len);
 
-            status = MagickSetImageProfile(canvas_wand, origin_image_profiles[i], profile, profile_len);
+                status = MagickSetImageProfile(canvas_wand, origin_image_profiles[i], profile, profile_len);
 
-            if (status == MagickFalse) {
-              r->err_status = NGX_HTTP_INTERNAL_SERVER_ERROR;
-              DestroyMagickWand(canvas_wand);
-              DestroyString(of_orig);
-              return NGX_ERROR;
+                if (status == MagickFalse) {
+                    r->err_status = NGX_HTTP_INTERNAL_SERVER_ERROR;
+                    DestroyMagickWand(canvas_wand);
+                    DestroyString(of_orig);
+                    return NGX_ERROR;
+                }
             }
-          }
         }
 
         DestroyMagickWand(ictx->wand);

--- a/src/ngx_http_small_light_imagemagick.c
+++ b/src/ngx_http_small_light_imagemagick.c
@@ -237,19 +237,21 @@ ngx_int_t ngx_http_small_light_imagemagick_process(ngx_http_request_t *r, ngx_ht
             return NGX_ERROR;
         }
 
-        /* copy original image profiles to the new canvas. */
-        origin_image_profiles = MagickGetImageProfiles(ictx->wand, "*", &profile_count);
-        if (origin_image_profiles != (char **) NULL) {
-            for (i = 0; i < profile_count; i++) {
-                profile = MagickGetImageProfile(ictx->wand, origin_image_profiles[i], &profile_len);
+        if (rmprof_flg == 0) {
+            /* copy original image profiles to the new canvas. */
+            origin_image_profiles = MagickGetImageProfiles(ictx->wand, "*", &profile_count);
+            if (origin_image_profiles != (char **) NULL) {
+                for (i = 0; i < profile_count; i++) {
+                    profile = MagickGetImageProfile(ictx->wand, origin_image_profiles[i], &profile_len);
 
-                status = MagickSetImageProfile(canvas_wand, origin_image_profiles[i], profile, profile_len);
+                    status = MagickSetImageProfile(canvas_wand, origin_image_profiles[i], profile, profile_len);
 
-                if (status == MagickFalse) {
-                    r->err_status = NGX_HTTP_INTERNAL_SERVER_ERROR;
-                    DestroyMagickWand(canvas_wand);
-                    DestroyString(of_orig);
-                    return NGX_ERROR;
+                    if (status == MagickFalse) {
+                        r->err_status = NGX_HTTP_INTERNAL_SERVER_ERROR;
+                        DestroyMagickWand(canvas_wand);
+                        DestroyString(of_orig);
+                        return NGX_ERROR;
+                    }
                 }
             }
         }

--- a/src/ngx_http_small_light_imagemagick.c
+++ b/src/ngx_http_small_light_imagemagick.c
@@ -252,8 +252,10 @@ ngx_int_t ngx_http_small_light_imagemagick_process(ngx_http_request_t *r, ngx_ht
                         DestroyString(of_orig);
                         return NGX_ERROR;
                     }
+                    MagickRelinquishMemory(profile);
                 }
             }
+            MagickRelinquishMemory(origin_image_profiles);
         }
 
         DestroyMagickWand(ictx->wand);

--- a/src/ngx_http_small_light_imagemagick.c
+++ b/src/ngx_http_small_light_imagemagick.c
@@ -87,7 +87,7 @@ ngx_int_t ngx_http_small_light_imagemagick_process(ngx_http_request_t *r, ngx_ht
     u_char                                  jpeg_size_opt[32], crop_geo[128], size_geo[128], embedicon_path[256];
     ColorspaceType                          color_space;
     char                                  **origin_image_profiles;
-    unsigned long                           profile_count, i;
+    size_t                                  profile_count, i;
 
 #if MagickLibVersion >= 0x690
     int                                     autoorient_flg;

--- a/src/ngx_http_small_light_imagemagick.c
+++ b/src/ngx_http_small_light_imagemagick.c
@@ -239,7 +239,7 @@ ngx_int_t ngx_http_small_light_imagemagick_process(ngx_http_request_t *r, ngx_ht
 
         /* copy original image profiles to the new canvas. */
         origin_image_profiles = MagickGetImageProfiles(ictx->wand, "*", &profile_count);
-        if (profiles != (char **) NULL) {
+        if (origin_image_profiles != (char **) NULL) {
           for (i = 0; i < profile_count; i++) {
             profile = MagickGetImageProfile(ictx->wand, origin_image_profiles[i], &profile_len);
 


### PR DESCRIPTION
When create new canvas(cw, ch parameter passed), new image lose image
profiles.
So copy image profiles to the new canvas.
