### PR TITLE
MagickWandGenesis is deprecated and it should be replace with  IsMagickWandInstantiated

### DIFF
--- a/config.in
+++ b/config.in
@@ -8,7 +8,7 @@ ngx_feature_incs="#include <wand/MagickWand.h>
 #include <gd.h>
 "
 ngx_feature_path=
-ngx_feature_test="MagickWandGenesis();
+ngx_feature_test="IsMagickWandInstantiated();
 Imlib_Image img_imlib2 = imlib_create_image(300, 300);
 gdImagePtr img_gd = gdImageCreate(300, 300);
 gdImagePtr img_gd_webp; int size = 0;


### PR DESCRIPTION
For example, Ubuntu 16.04 (Xenial Xerus) doesn't support MagickWandGenesis, but IsMagickWandInstantiated.