### PR TITLE
Convert the first frame of Animated GIF w/ ImageMagick

### DIFF
--- a/src/ngx_http_small_light_imagemagick.c
+++ b/src/ngx_http_small_light_imagemagick.c
@@ -115,6 +115,8 @@ ngx_int_t ngx_http_small_light_imagemagick_process(ngx_http_request_t *r, ngx_ht
         return NGX_ERROR;
     }
 
+    MagickSetFirstIterator(ictx->wand);
+
     color_space = MagickGetImageColorspace(ictx->wand);
 
     /* remove all profiles */


### PR DESCRIPTION
## WHY
When Animated GIF is given, ngx_small_light converts the _last_ frame of given animation. As described at  #25, this behavior is not good for [Overlay (frame-optimized) Animation](http://www.imagemagick.org/Usage/anim_basics/#overlay). Returned image is just a diff with transparent background from the previous frame.

I agree with you that converting entire animation is not realistic.

## WHAT
This patch makes it convert the _first_ frame of given animation. This patch only affects ImageMagick.

Conversion result of http://i.imgur.com/mDsYBAU.gif (used at #25) is http://i.imgur.com/EIW2AV4.gif (query is `small_light(of=gif)`). It works fine both Overlay and Coalesce Animation.