### PR TITLE
bugfix: fixed strange size calculation behavior. refs #46

### DIFF
--- a/src/ngx_http_small_light_imagemagick.c
+++ b/src/ngx_http_small_light_imagemagick.c
@@ -98,12 +98,11 @@ ngx_int_t ngx_http_small_light_imagemagick_process(ngx_http_request_t *r, ngx_ht
     ngx_http_small_light_calc_image_size(r, ctx, &sz, 10000.0, 10000.0);
 
     /* prepare */
-    if (sz.jpeghint_flg != 0) {
-        if (sz.dw == NGX_HTTP_SMALL_LIGHT_COORD_INVALID_VALUE && sz.dh == NGX_HTTP_SMALL_LIGHT_COORD_INVALID_VALUE) {
-            p = ngx_snprintf((u_char *)jpeg_size_opt, sizeof(jpeg_size_opt) - 1, "%dx%d", 10000.0, 10000.0);
-        } else {
-            p = ngx_snprintf((u_char *)jpeg_size_opt, sizeof(jpeg_size_opt) - 1, "%dx%d", (ngx_int_t)sz.dw, (ngx_int_t)sz.dh);
-        }
+    if (sz.jpeghint_flg != 0 &&
+        sz.dw != NGX_HTTP_SMALL_LIGHT_COORD_INVALID_VALUE &&
+        sz.dh != NGX_HTTP_SMALL_LIGHT_COORD_INVALID_VALUE)
+    {
+        p = ngx_snprintf((u_char *)jpeg_size_opt, sizeof(jpeg_size_opt) - 1, "%dx%d", (ngx_int_t)sz.dw, (ngx_int_t)sz.dh);
         *p = '\0';
         ngx_log_error(NGX_LOG_DEBUG, r->connection->log, 0, "jpeg_size_opt:%s", jpeg_size_opt);
         MagickSetOption(ictx->wand, "jpeg:size", (char *)jpeg_size_opt);

--- a/src/ngx_http_small_light_imagemagick.c
+++ b/src/ngx_http_small_light_imagemagick.c
@@ -99,7 +99,11 @@ ngx_int_t ngx_http_small_light_imagemagick_process(ngx_http_request_t *r, ngx_ht
 
     /* prepare */
     if (sz.jpeghint_flg != 0) {
-        p = ngx_snprintf((u_char *)jpeg_size_opt, sizeof(jpeg_size_opt) - 1, "%dx%d", (ngx_int_t)sz.dw, (ngx_int_t)sz.dh);
+        if (sz.dw == NGX_HTTP_SMALL_LIGHT_COORD_INVALID_VALUE && sz.dh == NGX_HTTP_SMALL_LIGHT_COORD_INVALID_VALUE) {
+            p = ngx_snprintf((u_char *)jpeg_size_opt, sizeof(jpeg_size_opt) - 1, "%dx%d", 10000.0, 10000.0);
+        } else {
+            p = ngx_snprintf((u_char *)jpeg_size_opt, sizeof(jpeg_size_opt) - 1, "%dx%d", (ngx_int_t)sz.dw, (ngx_int_t)sz.dh);
+        }
         *p = '\0';
         ngx_log_error(NGX_LOG_DEBUG, r->connection->log, 0, "jpeg_size_opt:%s", jpeg_size_opt);
         MagickSetOption(ictx->wand, "jpeg:size", (char *)jpeg_size_opt);
@@ -183,6 +187,14 @@ ngx_int_t ngx_http_small_light_imagemagick_process(ngx_http_request_t *r, ngx_ht
         ctx->of = ctx->inf;
         DestroyString(of_orig);
         return NGX_OK;
+    }
+
+    /* adjust destination size */
+    if (sz.dw == NGX_HTTP_SMALL_LIGHT_COORD_INVALID_VALUE) {
+        sz.dw = sz.sw;
+    }
+    if (sz.dh == NGX_HTTP_SMALL_LIGHT_COORD_INVALID_VALUE) {
+        sz.dh = sz.sh;
     }
 
     /* crop, scale. */

--- a/src/ngx_http_small_light_imlib2.c
+++ b/src/ngx_http_small_light_imlib2.c
@@ -124,7 +124,10 @@ ngx_int_t ngx_http_small_light_imlib2_process(ngx_http_request_t *r, ngx_http_sm
     /* adjust image size */
     ngx_http_small_light_calc_image_size(r, ctx, &sz, 10000.0, 10000.0);
 
-    if (sz.jpeghint_flg != 0) {
+    if (sz.jpeghint_flg != 0 &&
+        sz.dw != NGX_HTTP_SMALL_LIGHT_COORD_INVALID_VALUE &&
+        sz.dh != NGX_HTTP_SMALL_LIGHT_COORD_INVALID_VALUE)
+    {
         if (ngx_http_small_light_load_jpeg((void**)&data, &w, &h, r, filename, sz.dw, sz.dh) != NGX_OK) {
             image_org = imlib_load_image_immediately_without_cache(filename);
             if (image_org == NULL) {

--- a/src/ngx_http_small_light_imlib2.c
+++ b/src/ngx_http_small_light_imlib2.c
@@ -189,6 +189,14 @@ ngx_int_t ngx_http_small_light_imlib2_process(ngx_http_request_t *r, ngx_http_sm
         return NGX_OK;
     }
 
+    /* adjust destination size */
+    if (sz.dw == NGX_HTTP_SMALL_LIGHT_COORD_INVALID_VALUE) {
+        sz.dw = sz.sw;
+    }
+    if (sz.dh == NGX_HTTP_SMALL_LIGHT_COORD_INVALID_VALUE) {
+        sz.dh = sz.sh;
+    }
+
     /* crop, scale. */
     if (sz.scale_flg != 0) {
         image_dst = imlib_create_cropped_scaled_image((int)sz.sx, (int)sz.sy, (int)sz.sw, (int)sz.sh, (int)sz.dw, (int)sz.dh);

--- a/src/ngx_http_small_light_size.c
+++ b/src/ngx_http_small_light_size.c
@@ -38,7 +38,6 @@ void ngx_http_small_light_calc_image_size(ngx_http_request_t *r,
     ngx_http_small_light_coord_t  sx_coord, sy_coord, sw_coord, sh_coord;
     ngx_http_small_light_coord_t  dx_coord, dy_coord, dw_coord, dh_coord;
     char                         *da_str, *pt, *prm_ds_str, da, prm_ds;
-    double                        dwo;
     ngx_int_t                     pt_flg;
 
     ngx_http_small_light_parse_coord(&sx_coord, NGX_HTTP_SMALL_LIGHT_PARAM_GET_LIT(&ctx->hash, "sx"));
@@ -90,9 +89,7 @@ void ngx_http_small_light_calc_image_size(ngx_http_request_t *r,
         }
     } else {
         if (sz->dw == NGX_HTTP_SMALL_LIGHT_COORD_INVALID_VALUE && sz->dh == sz->dw) {
-            dwo = sz->dw;
-            sz->dw = sz->dh / sz->aspect;
-            sz->dh = dwo / sz->aspect;
+            // do nothing
         } else if (sz->dw == NGX_HTTP_SMALL_LIGHT_COORD_INVALID_VALUE) {
             sz->dw = sz->dh * sz->aspect;
         } else if (sz->dh == NGX_HTTP_SMALL_LIGHT_COORD_INVALID_VALUE) {
@@ -135,8 +132,6 @@ void ngx_http_small_light_calc_image_size(ngx_http_request_t *r,
         sz->scale_flg = 1;
     } else {
         sz->scale_flg = 0;
-        sz->dw = iw;
-        sz->dh = ih;
     }
     if (sz->dx == NGX_HTTP_SMALL_LIGHT_COORD_INVALID_VALUE) {
         sz->dx = (sz->cw - sz->dw) * 0.5;

--- a/src/ngx_http_small_light_size.c
+++ b/src/ngx_http_small_light_size.c
@@ -105,12 +105,6 @@ void ngx_http_small_light_calc_image_size(ngx_http_request_t *r,
     ngx_http_small_light_parse_color(&sz->cc,  NGX_HTTP_SMALL_LIGHT_PARAM_GET_LIT(&ctx->hash, "cc"));
     ngx_http_small_light_parse_color(&sz->bc,  NGX_HTTP_SMALL_LIGHT_PARAM_GET_LIT(&ctx->hash, "bc"));
 
-    ngx_log_error(NGX_LOG_NOTICE, r->connection->log, 0,
-                  "size info:sx=%f,sy=%f,sw=%f,sh=%f,dw=%f,dh=%f,cw=%f,ch=%f,bw=%f,bh=%f,ix=%i,iy=%i",
-                  sz->sx, sz->sy, sz->sw, sz->sh,
-                  sz->dw, sz->dh, sz->cw, sz->ch, sz->bw, sz->bh, 
-                  sz->ix, sz->iy);
-
     /* get pass through option. */
     pt_flg = 0;
     pt     = NGX_HTTP_SMALL_LIGHT_PARAM_GET_LIT(&ctx->hash, "pt");
@@ -143,4 +137,9 @@ void ngx_http_small_light_calc_image_size(ngx_http_request_t *r,
     sz->jpeghint_flg = ngx_http_small_light_parse_flag(NGX_HTTP_SMALL_LIGHT_PARAM_GET_LIT(&ctx->hash, "jpeghint"));
     sz->angle        = ngx_http_small_light_parse_int(NGX_HTTP_SMALL_LIGHT_PARAM_GET_LIT(&ctx->hash, "angle"));
 
+    ngx_log_error(NGX_LOG_NOTICE, r->connection->log, 0,
+                  "size info:sx=%f,sy=%f,sw=%f,sh=%f,dw=%f,dh=%f,cw=%f,ch=%f,bw=%f,bh=%f,ix=%i,iy=%i",
+                  sz->sx, sz->sy, sz->sw, sz->sh,
+                  sz->dw, sz->dh, sz->cw, sz->ch, sz->bw, sz->bh, 
+                  sz->ix, sz->iy);
 }


### PR DESCRIPTION
When destination size such as `dw` and `dh` is not set,
`NGX_HTTP_SMALL_LIGHT_COORD_INVALID_VALUE(1.e+38)` is used.
Usually, source size should be used.