### PR TITLE
imagemagick: adjusted image offset automatically. fixes #44

### DIFF
--- a/src/ngx_http_small_light_imagemagick.c
+++ b/src/ngx_http_small_light_imagemagick.c
@@ -46,8 +46,8 @@ void ngx_http_small_light_imagemagick_adjust_image_offset(ngx_http_request_t *r,
         return;
     }
 
-    sz->sx = x;
-    sz->sy = y;
+    sz->sx = (double) x;
+    sz->sy = (double) y;
 }
 
 ngx_int_t ngx_http_small_light_imagemagick_init(ngx_http_request_t *r, ngx_http_small_light_ctx_t *ctx)


### PR DESCRIPTION
refs: #44

Some image has offset information like below.

```
$ identify image.png
image.png PNG 480x220 480x580+0+360 8-bit DirectClass 65KB 0.000u 0:00.000
```

Such image needs to be adjust offset for converting as intended.
ngx_small_light already has the parameters such as `sx` and `sy` for do it.