### PR TITLE
added parameter "rmalpha"

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,6 +273,7 @@ when Content-Length is not set in response headers.
 |cmyk2rgb   |char  |n          |convert colorspace from CMYK to sRGB (y, n)     |        :o:|   :x:|:x:|
 |rmprof     |char  |n          |remove profile (y, n)                           |        :o:|   :x:|:x:|
 |autoorient |char  |n          |enable adjust image orientation automatically (y, n)  |  :o:|   :x:|:x:|
+|rmalpha    |char  |n          |remove alpha channel (y, n)                     |        :o:|   :x:|:x:|
 
 The values of `da` are `l` and `s` and `n`. These present the meanings below.
 

--- a/src/ngx_http_small_light_imagemagick.c
+++ b/src/ngx_http_small_light_imagemagick.c
@@ -97,7 +97,7 @@ ngx_int_t ngx_http_small_light_imagemagick_process(ngx_http_request_t *r, ngx_ht
     ngx_http_small_light_imagemagick_ctx_t *ictx;
     ngx_http_small_light_image_size_t       sz;
     MagickBooleanType                       status;
-    int                                     rmprof_flg, progressive_flg, cmyk2rgb_flg;
+    int                                     rmprof_flg, progressive_flg, cmyk2rgb_flg, rmalpha_flg;
     double                                  iw, ih, q;
     char                                   *unsharp, *sharpen, *blur, *of, *of_orig;
     MagickWand                             *trans_wand, *canvas_wand;
@@ -155,6 +155,18 @@ ngx_int_t ngx_http_small_light_imagemagick_process(ngx_http_request_t *r, ngx_ht
         if (status == MagickFalse) {
             ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
                           "couldn't profiling image %s:%d",
+                          __FUNCTION__,
+                          __LINE__);
+        }
+    }
+
+    /* remove alpha channel */
+    rmalpha_flg = ngx_http_small_light_parse_flag(NGX_HTTP_SMALL_LIGHT_PARAM_GET_LIT(&ctx->hash, "rmalpha"));
+    if (rmalpha_flg != 0) {
+        status = MagickSetImageAlphaChannel(ictx->wand, RemoveAlphaChannel);
+        if (status == MagickFalse) {
+            ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
+                          "couldn't remove alpha channel from image %s:%d",
                           __FUNCTION__,
                           __LINE__);
         }

--- a/src/ngx_http_small_light_param.c
+++ b/src/ngx_http_small_light_param.c
@@ -64,7 +64,8 @@ static const ngx_http_small_light_param_t ngx_http_small_light_params[] = {
     { ngx_string("progressive"), "n"},
     { ngx_string("cmyk2rgb"),  "n"},
     { ngx_string("rmprof"),    "n"},
-    { ngx_string("autoorient"),"n"}
+    { ngx_string("autoorient"),"n"},
+    { ngx_string("rmalpha"),   "n"}
 };
 
 static const ngx_str_t ngx_http_small_light_getparams[] = {
@@ -100,7 +101,8 @@ static const ngx_str_t ngx_http_small_light_getparams[] = {
     ngx_string("arg_progressive"),
     ngx_string("arg_cmyk2rgb"),
     ngx_string("arg_rmprof"),
-    ngx_string("arg_autoorient")
+    ngx_string("arg_autoorient"),
+    ngx_string("arg_rmalpha")
 };
 
 static void ngx_http_small_light_init_params_default(ngx_http_small_light_ctx_t *ctx)


### PR DESCRIPTION
Converting PNG with transparent alpha channel to JPEG results to image with black background no metter what background (canvas) color is defined. This PR allows to remove alpha channel from resulting image making possible to set background color while converting to JPEG.