### PR TITLE
 error: field ‘pkt6’ has incomplete type

### DIFF
--- a/src/ngx_http_small_light_gd.h
+++ b/src/ngx_http_small_light_gd.h
@@ -23,9 +23,8 @@
 #ifndef NGX_HTTP_SMALL_LIGHT_GD_H
 #define NGX_HTTP_SMALL_LIGHT_GD_H
 
-#include <gd.h>
-
 #include "ngx_http_small_light_module.h"
+#include <gd.h>
 
 typedef struct {
     u_char *image;

--- a/src/ngx_http_small_light_imagemagick.h
+++ b/src/ngx_http_small_light_imagemagick.h
@@ -23,9 +23,8 @@
 #ifndef NGX_HTTP_SMALL_LIGHT_IMAGEMAGICK_H
 #define NGX_HTTP_SMALL_LIGHT_IMAGEMAGICK_H
 
-#include <wand/MagickWand.h>
-
 #include "ngx_http_small_light_module.h"
+#include <wand/MagickWand.h>
 
 typedef struct {
     u_char *image;

--- a/src/ngx_http_small_light_imlib2.h
+++ b/src/ngx_http_small_light_imlib2.h
@@ -23,9 +23,8 @@
 #ifndef NGX_HTTP_SMALL_LIGHT_IMLIB2_H
 #define NGX_HTTP_SMALL_LIGHT_IMLIB2_H
 
-#include <Imlib2.h>
-
 #include "ngx_http_small_light_module.h"
+#include <Imlib2.h>
 
 typedef struct {
     u_char *image;

--- a/src/ngx_http_small_light_jpeg.c
+++ b/src/ngx_http_small_light_jpeg.c
@@ -21,7 +21,8 @@
    THE SOFTWARE.
 */
 
-#include <nginx.h>
+#include <ngx_config.h>
+#include <ngx_core.h>
 
 #include <Imlib2.h>
 #include <setjmp.h>


### PR DESCRIPTION
Issue
``
        src/event/ngx_event_udp.h:38:27: error: field ‘pkt6’ has incomplete type
             struct in6_pktinfo    pkt6;
```
Comment:

Change Include Headers According to below guide.
http://nginx.org/en/docs/dev/development_guide.html#include_files
https://trac.nginx.org/nginx/ticket/2312#comment:4